### PR TITLE
Multiple page per template

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,5 @@
   :url "https://github.com/tomfaulhaber/excel-templates"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.apache.poi/poi-ooxml "3.10-FINAL"]])
+  :dependencies [[org.clojure/clojure      "1.6.0"]
+                 [org.apache.poi/poi-ooxml "3.10-FINAL"]])


### PR DESCRIPTION
This adds support for the format discussed in issue #4. It also maintains backward compatibility for the original format with one exception: The simplest case {2 [[nil "foo"]]}, for workbooks of only one sheet isn't supported. If that's something you'd like to keep, I can work on that next -- just didn't want to hold up the PR.