### PR TITLE
Reads template resources as input-streams

### DIFF
--- a/src/excel_templates/build.clj
+++ b/src/excel_templates/build.clj
@@ -166,7 +166,7 @@ If there are any nil values in the source collection, the corresponding cells ar
   (let [f (io/file template-file)]
     (if (.exists f)
       f
-      (-> template-file io/resource io/file))))
+      (-> template-file io/resource io/input-stream))))
 
 
 (defn build-base-output


### PR DESCRIPTION
When one tries to read a resource template from a jar via
io/resource, it returns a URL using the jar:file: protocol, which
isn't supported. This way, we return an input-stream, which is accepted
by io/copy.
    
This whole issue is masked when running from the REPL, since the
file can then be found on the filesystem, and relying on the jar
isn't necessary.