### PR TITLE
Update cached results for each formula in workbook

### DIFF
--- a/src/excel_templates/build.clj
+++ b/src/excel_templates/build.clj
@@ -424,6 +424,9 @@ If there are any nil values in the source collection, the corresponding cells ar
                                     (copy-styles wb src-row new-row)))
                                 (recur (inc src-row-num) (inc dst-row-num)))))))
                       (c/transform-charts sheet translation-table))
+                    ;; Update cached results for each formula:
+                    ;; https://poi.apache.org/spreadsheet/eval.html
+                    (-> wb .getCreationHelper .createFormulaEvaluator .evaluateAll)
                     ;; Write the resulting output Workbook
                     (with-open [fos (FileOutputStream. (nth outputs sheet-num))]
                       (.write wb fos))


### PR DESCRIPTION
Hi!

Fix for problem where formula-results aren’t cached. (I can reproduce if you wish.)

Alternatives:
- If performance is a prob, I should look a bit more closely at `set-formula`? Was [`(.evaluateFormulaCell cell)`](https://github.com/tomfaulhaber/excel-templates/blob/master/src/excel_templates/build.clj#L112) supposed to avoid exactly this?
- Open API to allow user to run arbitrary stuff on worksheet, before saving?
