### PR TITLE
Ensure the template file is closable

### DIFF
--- a/src/excel_templates/build.clj
+++ b/src/excel_templates/build.clj
@@ -177,7 +177,7 @@ If there are any nil values in the source collection, the corresponding cells ar
   [template-file]
   (let [f (io/file template-file)]
     (if (.exists f)
-      f
+      (io/input-stream f)
       (-> template-file io/resource io/input-stream))))
 
 


### PR DESCRIPTION
If you tried to use multi-sheets on a chart which is on the local filesystem, the `with-open` on line 496 would throw an exception, since `java.io.File` doesn't support `.close`. This is one solution--forcing everything to be closeable. It has the downside of not using the kernel's file copy API when possible; however, I think that probably doesn't matter. It could be made faster in certain cases by doing checks in the `with-open`.